### PR TITLE
Fixed inconsistent behavior.

### DIFF
--- a/examples/tweens/tween several properties.js
+++ b/examples/tweens/tween several properties.js
@@ -20,10 +20,10 @@ function create() {
         item.anchor.setTo(0.5,0.5);
 
         // Add a simple bounce tween to each character's position.
-        game.add.tween(item).to({y: 240}, 2400, Phaser.Easing.Bounce.Out, true, 1000 + 400 * i, false);
+        game.add.tween(item).to({y: 240}, 2400, Phaser.Easing.Bounce.Out, true, 1000 + 400 * i, 0);
 
         // Add another rotation tween to the same character.
-        game.add.tween(item).to({angle: 360}, 2400, Phaser.Easing.Cubic.In, true, 1000 + 400 * i, false);
+        game.add.tween(item).to({angle: 360}, 2400, Phaser.Easing.Cubic.In, true, 1000 + 400 * i, 0);
     }
 
 }


### PR DESCRIPTION
The arguments to Phaser.Tween.to are:
to(properties, duration, ease, autoStart, delay, repeat, yoyo) → {Phaser.Tween}

The original example's code had "false" as the last parameter, which must be a simple mistake as "repeat" is supposed to be a number instead of a boolean. A commenter had noted that the tween animation repeats forever with "repeat" set to false, whereas it should be set to "0".

Nothing fancy, just fixing an inconsistency.